### PR TITLE
feat(mintv2): add cancellable sends

### DIFF
--- a/modules/fedimint-mintv2-client/src/client_db.rs
+++ b/modules/fedimint-mintv2-client/src/client_db.rs
@@ -15,6 +15,8 @@ use crate::issuance::NoteIssuanceRequest;
 pub enum DbKeyPrefix {
     Note = 0x20,
     RecoveryState = 0x21,
+    CancelledSend = 0x22,
+    CancellableSend = 0x23,
 }
 
 #[derive(Debug, Clone, Encodable, Decodable)]
@@ -61,4 +63,23 @@ impl_db_record!(
     key = RecoveryStateKey,
     value = RecoveryState,
     db_prefix = DbKeyPrefix::RecoveryState,
+);
+
+#[derive(Debug, Clone, Encodable, Decodable)]
+pub struct CancelledSendKey(pub fedimint_core::core::OperationId);
+
+impl_db_record!(
+    key = CancelledSendKey,
+    value = (),
+    db_prefix = DbKeyPrefix::CancelledSend,
+    notify_on_modify = true,
+);
+
+#[derive(Debug, Clone, Encodable, Decodable)]
+pub struct CancellableSendKey(pub fedimint_core::core::OperationId);
+
+impl_db_record!(
+    key = CancellableSendKey,
+    value = (),
+    db_prefix = DbKeyPrefix::CancellableSend,
 );

--- a/modules/fedimint-mintv2-client/src/lib.rs
+++ b/modules/fedimint-mintv2-client/src/lib.rs
@@ -19,15 +19,19 @@ mod input;
 pub mod issuance;
 mod output;
 mod receive;
+mod send_cancellable;
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::convert::Infallible;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
-use anyhow::{Context as _, anyhow};
+use anyhow::{Context as _, anyhow, bail};
 use bitcoin_hashes::sha256;
-use client_db::{RecoveryState, RecoveryStateKey, SpendableNoteAmountPrefix, SpendableNotePrefix};
+use client_db::{
+    CancellableSendKey, CancelledSendKey, RecoveryState, RecoveryStateKey,
+    SpendableNoteAmountPrefix, SpendableNotePrefix,
+};
 pub use events::*;
 use fedimint_api_client::api::DynModuleApi;
 use fedimint_client::module::ClientModule;
@@ -43,6 +47,7 @@ use fedimint_client_module::module::recovery::{NoModuleBackup, RecoveryProgress}
 use fedimint_client_module::module::{
     ClientContext, OutPointRange, PrimaryModulePriority, PrimaryModuleSupport,
 };
+use fedimint_client_module::oplog::{OperationLogEntry, UpdateStreamOrOutcome};
 use fedimint_client_module::sm::{Context, DynState, ModuleNotifier, State, StateTransition};
 use fedimint_client_module::{DynGlobalClientContext, sm_enum_variant_translation};
 use fedimint_core::base32::{self, FEDIMINT_PREFIX};
@@ -55,7 +60,7 @@ use fedimint_core::module::{
 };
 use fedimint_core::secp256k1::rand::{Rng, thread_rng};
 use fedimint_core::secp256k1::{Keypair, PublicKey};
-use fedimint_core::util::{BoxStream, NextOrPending};
+use fedimint_core::util::{BoxFuture, BoxStream, NextOrPending};
 use fedimint_core::{Amount, OutPoint, PeerId, apply, async_trait_maybe_send};
 use fedimint_derive_secret::DerivableSecret;
 use fedimint_mintv2_common::config::{FeeConsensus, MintClientConfig, client_denominations};
@@ -77,6 +82,10 @@ use crate::input::{InputSMCommon, InputSMState, InputStateMachine};
 use crate::issuance::NoteIssuanceRequest;
 use crate::output::{MintOutputStateMachine, OutputSMCommon, OutputSMState};
 use crate::receive::{ReceiveSMState, ReceiveStateMachine};
+use crate::send_cancellable::{
+    SendCancellableSMCommon, SendCancellableSMCreated, SendCancellableSMState,
+    SendCancellableStateMachine,
+};
 
 const TARGET_PER_DENOMINATION: usize = 3;
 const SLICE_SIZE: u64 = 10000;
@@ -341,9 +350,19 @@ pub struct MintClientModule {
 #[derive(Debug, Clone)]
 pub struct MintClientContext {
     client_ctx: ClientContext<MintClientModule>,
+    amount_unit: AmountUnit,
     tbs_agg_pks: BTreeMap<Denomination, AggregatePublicKey>,
     tbs_pks: BTreeMap<Denomination, BTreeMap<PeerId, tbs::PublicKeyShare>>,
     pub balance_update_sender: tokio::sync::watch::Sender<()>,
+}
+
+impl MintClientContext {
+    fn await_cancel_send(&self, operation_id: OperationId) -> BoxFuture<'static, ()> {
+        let db = self.client_ctx.module_db().clone();
+        Box::pin(async move {
+            db.wait_key_exists(&CancelledSendKey(operation_id)).await;
+        })
+    }
 }
 
 impl Context for MintClientContext {
@@ -361,6 +380,7 @@ impl ClientModule for MintClientModule {
     fn context(&self) -> Self::ModuleStateMachineContext {
         MintClientContext {
             client_ctx: self.client_ctx.clone(),
+            amount_unit: self.cfg.amount_unit,
             tbs_agg_pks: self.cfg.tbs_agg_pks.clone(),
             tbs_pks: self.cfg.tbs_pks.clone(),
             balance_update_sender: self.balance_update_sender.clone(),
@@ -776,6 +796,30 @@ impl MintClientModule {
         custom_meta: Value,
         include_invite: bool,
     ) -> Result<(OperationId, ECash), SendECashError> {
+        Box::pin(self.send_inner(amount, custom_meta, include_invite, None)).await
+    }
+
+    /// Send `ECash` for the given amount and make the send cancellable by
+    /// calling [`MintClientModule::try_cancel_send_cancellable`] before the
+    /// recipient reissues the ecash. If the ecash was not reissued before
+    /// `try_cancel_after`, the client will automatically attempt to reclaim it.
+    pub async fn send_cancellable(
+        &self,
+        amount: Amount,
+        custom_meta: Value,
+        include_invite: bool,
+        try_cancel_after: Duration,
+    ) -> Result<(OperationId, ECash), SendECashError> {
+        Box::pin(self.send_inner(amount, custom_meta, include_invite, Some(try_cancel_after))).await
+    }
+
+    async fn send_inner(
+        &self,
+        amount: Amount,
+        custom_meta: Value,
+        include_invite: bool,
+        try_cancel_after: Option<Duration>,
+    ) -> Result<(OperationId, ECash), SendECashError> {
         let amount = round_to_multiple(amount, client_denominations().next().unwrap().amount());
 
         if let Some((operation_id, ecash)) = self
@@ -788,6 +832,7 @@ impl MintClientModule {
                         amount,
                         custom_meta.clone(),
                         include_invite,
+                        try_cancel_after,
                     ))
                 },
                 Some(100),
@@ -833,7 +878,7 @@ impl MintClientModule {
                 .map_err(|_| SendECashError::Failure)?;
         }
 
-        Box::pin(self.send(amount, custom_meta, include_invite)).await
+        Box::pin(self.send_inner(amount, custom_meta, include_invite, try_cancel_after)).await
     }
 
     async fn send_ecash_dbtx(
@@ -842,6 +887,7 @@ impl MintClientModule {
         mut remaining_amount: Amount,
         custom_meta: Value,
         include_invite: bool,
+        try_cancel_after: Option<Duration>,
     ) -> Result<Option<(OperationId, ECash)>, Infallible> {
         let mut stream = dbtx
             .find_by_prefix_sorted_descending(&SpendableNotePrefix)
@@ -877,6 +923,7 @@ impl MintClientModule {
         };
         let amount = ecash.amount();
         let operation_id = OperationId::new_random();
+        let encoded_ecash = base32::encode_prefixed(FEDIMINT_PREFIX, &ecash);
 
         self.client_ctx
             .add_operation_log_entry_dbtx(
@@ -884,11 +931,36 @@ impl MintClientModule {
                 operation_id,
                 MintCommonInit::KIND.as_str(),
                 MintOperationMeta::Send {
-                    ecash: base32::encode_prefixed(FEDIMINT_PREFIX, &ecash),
+                    ecash: encoded_ecash.clone(),
                     custom_meta,
                 },
             )
             .await;
+
+        if let Some(try_cancel_after) = try_cancel_after {
+            dbtx.insert_new_entry(&CancellableSendKey(operation_id), &())
+                .await;
+
+            self.client_ctx
+                .add_state_machines_dbtx(
+                    dbtx,
+                    self.client_ctx
+                        .map_dyn(vec![MintClientStateMachines::SendCancellable(
+                            SendCancellableStateMachine {
+                                common: SendCancellableSMCommon {
+                                    operation_id,
+                                    spendable_notes: ecash.notes(),
+                                },
+                                state: SendCancellableSMState::Created(SendCancellableSMCreated {
+                                    timeout: fedimint_core::time::now() + try_cancel_after,
+                                }),
+                            },
+                        )])
+                        .collect(),
+                )
+                .await
+                .expect("Cancellable send state machine must be valid");
+        }
 
         self.client_ctx
             .log_event(
@@ -896,7 +968,7 @@ impl MintClientModule {
                 SendPaymentEvent {
                     operation_id,
                     amount,
-                    ecash: base32::encode_prefixed(FEDIMINT_PREFIX, &ecash),
+                    ecash: encoded_ecash,
                 },
             )
             .await;
@@ -966,6 +1038,154 @@ impl MintClientModule {
         dbtx.commit_tx().await;
 
         Ok(operation_id)
+    }
+
+    /// Try to cancel a cancellable send operation started with
+    /// [`MintClientModule::send_cancellable`]. If the e-cash notes have already
+    /// been spent this operation will fail, which can be observed using
+    /// [`MintClientModule::subscribe_send_cancellable`].
+    pub async fn try_cancel_send_cancellable(&self, operation_id: OperationId) {
+        self.client_ctx
+            .module_db()
+            .autocommit(
+                |dbtx, _| {
+                    Box::pin(async move {
+                        dbtx.insert_entry(&CancelledSendKey(operation_id), &())
+                            .await;
+                        Ok::<(), Infallible>(())
+                    })
+                },
+                Some(100),
+            )
+            .await
+            .expect("Failed to commit dbtx after 100 retries");
+    }
+
+    /// Subscribe to updates on the progress of a cancellable e-cash send
+    /// operation started with [`MintClientModule::send_cancellable`].
+    pub async fn subscribe_send_cancellable(
+        &self,
+        operation_id: OperationId,
+    ) -> anyhow::Result<UpdateStreamOrOutcome<SendCancellableOperationState>> {
+        let operation = self.mint_operation(operation_id).await?;
+        if !matches!(
+            operation.meta::<MintOperationMeta>(),
+            MintOperationMeta::Send { .. }
+        ) {
+            bail!("Operation is not an e-cash send");
+        }
+
+        let cancellable = self
+            .client_ctx
+            .module_db()
+            .begin_transaction_nc()
+            .await
+            .get_value(&CancellableSendKey(operation_id))
+            .await
+            .is_some();
+        if !cancellable {
+            bail!("Operation is not a cancellable e-cash send");
+        }
+
+        let client_ctx = self.client_ctx.clone();
+
+        Ok(self
+            .client_ctx
+            .outcome_or_updates(operation, operation_id, move || {
+                async_stream::stream! {
+                    yield SendCancellableOperationState::Created;
+
+                    let self_ref = client_ctx.self_ref();
+                    let refund = self_ref.await_send_cancellable_refund(operation_id).await;
+
+                    if refund.user_triggered {
+                        yield SendCancellableOperationState::UserCanceledProcessing;
+                    }
+
+                    let success = client_ctx
+                        .transaction_updates(operation_id)
+                        .await
+                        .await_tx_accepted(refund.refund_range.txid())
+                        .await
+                        .is_ok()
+                        && self_ref
+                            .await_send_cancellable_refund_outputs(
+                                operation_id,
+                                refund.refund_range,
+                            )
+                            .await
+                            .is_ok();
+
+                    match (refund.user_triggered, success) {
+                        (true, true) => {
+                            yield SendCancellableOperationState::UserCanceledSuccess;
+                        },
+                        (true, false) => {
+                            yield SendCancellableOperationState::UserCanceledFailure;
+                        },
+                        (false, true) => {
+                            yield SendCancellableOperationState::Refunded;
+                        },
+                        (false, false) => {
+                            yield SendCancellableOperationState::Success;
+                        }
+                    }
+                }
+            }))
+    }
+
+    async fn await_send_cancellable_refund(
+        &self,
+        operation_id: OperationId,
+    ) -> SendCancellableRefund {
+        Box::pin(
+            self.notifier
+                .subscribe(operation_id)
+                .await
+                .filter_map(|state| async {
+                    let MintClientStateMachines::SendCancellable(state) = state else {
+                        return None;
+                    };
+
+                    match state.state {
+                        SendCancellableSMState::UserRefund(refund) => Some(SendCancellableRefund {
+                            user_triggered: true,
+                            refund_range: refund.refund_range,
+                        }),
+                        SendCancellableSMState::TimeoutRefund(refund) => {
+                            Some(SendCancellableRefund {
+                                user_triggered: false,
+                                refund_range: refund.refund_range,
+                            })
+                        }
+                        SendCancellableSMState::Created(_) => None,
+                    }
+                }),
+        )
+        .next_or_pending()
+        .await
+    }
+
+    async fn await_send_cancellable_refund_outputs(
+        &self,
+        operation_id: OperationId,
+        refund_range: OutPointRange,
+    ) -> anyhow::Result<()> {
+        for outpoint in refund_range {
+            self.await_output_sm_success(operation_id, outpoint).await?;
+        }
+
+        Ok(())
+    }
+
+    async fn mint_operation(&self, operation_id: OperationId) -> anyhow::Result<OperationLogEntry> {
+        let operation = self.client_ctx.get_operation(operation_id).await?;
+
+        if operation.operation_module_kind() != MintCommonInit::KIND.as_str() {
+            bail!("Operation is not a mint operation");
+        }
+
+        Ok(operation)
     }
 
     /// Await the final state of the receive operation.
@@ -1128,11 +1348,39 @@ pub enum FinalReceiveOperationState {
     Rejected,
 }
 
+/// The high-level state of an e-cash send operation started with
+/// [`MintClientModule::send_cancellable`].
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub enum SendCancellableOperationState {
+    /// The e-cash has been selected and given to the caller.
+    Created,
+    /// The user requested a cancellation of the operation, and the client is
+    /// waiting for the outcome of the cancel transaction.
+    UserCanceledProcessing,
+    /// The user-requested cancellation transaction was accepted.
+    UserCanceledSuccess,
+    /// The user-requested cancellation failed, meaning the e-cash notes were
+    /// already spent by someone else.
+    UserCanceledFailure,
+    /// The automatic timeout cancellation failed, meaning the recipient
+    /// reissued the e-cash before timeout.
+    Success,
+    /// The automatic timeout cancellation transaction was accepted, meaning the
+    /// recipient did not reissue the e-cash before timeout.
+    Refunded,
+}
+
+struct SendCancellableRefund {
+    user_triggered: bool,
+    refund_range: OutPointRange,
+}
+
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub enum MintClientStateMachines {
     Input(InputStateMachine),
     Output(MintOutputStateMachine),
     Receive(ReceiveStateMachine),
+    SendCancellable(SendCancellableStateMachine),
 }
 
 impl IntoDynInstance for MintClientStateMachines {
@@ -1170,6 +1418,12 @@ impl State for MintClientStateMachines {
                     MintClientStateMachines::Receive
                 )
             }
+            MintClientStateMachines::SendCancellable(send_state) => {
+                sm_enum_variant_translation!(
+                    send_state.transitions(context, global_context),
+                    MintClientStateMachines::SendCancellable
+                )
+            }
         }
     }
 
@@ -1178,6 +1432,7 @@ impl State for MintClientStateMachines {
             MintClientStateMachines::Input(redemption_state) => redemption_state.operation_id(),
             MintClientStateMachines::Output(issuance_state) => issuance_state.operation_id(),
             MintClientStateMachines::Receive(receive_state) => receive_state.operation_id(),
+            MintClientStateMachines::SendCancellable(send_state) => send_state.operation_id(),
         }
     }
 }

--- a/modules/fedimint-mintv2-client/src/send_cancellable.rs
+++ b/modules/fedimint-mintv2-client/src/send_cancellable.rs
@@ -1,0 +1,145 @@
+use std::time::SystemTime;
+
+use fedimint_client::DynGlobalClientContext;
+use fedimint_client::transaction::{ClientInput, ClientInputBundle};
+use fedimint_client_module::module::OutPointRange;
+use fedimint_client_module::sm::{ClientSMDatabaseTransaction, State, StateTransition};
+use fedimint_core::core::OperationId;
+use fedimint_core::encoding::{Decodable, Encodable};
+use fedimint_core::module::Amounts;
+use fedimint_core::{runtime, time};
+use fedimint_mintv2_common::MintInput;
+
+use crate::{MintClientContext, SpendableNote};
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
+pub struct SendCancellableStateMachine {
+    pub common: SendCancellableSMCommon,
+    pub state: SendCancellableSMState,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
+pub struct SendCancellableSMCommon {
+    pub operation_id: OperationId,
+    pub spendable_notes: Vec<SpendableNote>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
+pub enum SendCancellableSMState {
+    Created(SendCancellableSMCreated),
+    UserRefund(SendCancellableSMRefund),
+    TimeoutRefund(SendCancellableSMRefund),
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
+pub struct SendCancellableSMCreated {
+    pub timeout: SystemTime,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
+pub struct SendCancellableSMRefund {
+    pub refund_range: OutPointRange,
+}
+
+impl State for SendCancellableStateMachine {
+    type ModuleContext = MintClientContext;
+
+    fn transitions(
+        &self,
+        context: &Self::ModuleContext,
+        global_context: &DynGlobalClientContext,
+    ) -> Vec<StateTransition<Self>> {
+        let SendCancellableSMState::Created(created) = &self.state else {
+            return vec![];
+        };
+
+        let manual_cancel_context = context.clone();
+        let manual_cancel_gc = global_context.clone();
+        let timeout_context = context.clone();
+        let timeout_gc = global_context.clone();
+
+        vec![
+            StateTransition::new(
+                context.await_cancel_send(self.common.operation_id),
+                move |dbtx, (), old_state| {
+                    Box::pin(Self::transition_cancel(
+                        dbtx,
+                        old_state,
+                        manual_cancel_context.clone(),
+                        manual_cancel_gc.clone(),
+                        true,
+                    ))
+                },
+            ),
+            StateTransition::new(
+                await_timeout_cancel(created.timeout),
+                move |dbtx, (), old_state| {
+                    Box::pin(Self::transition_cancel(
+                        dbtx,
+                        old_state,
+                        timeout_context.clone(),
+                        timeout_gc.clone(),
+                        false,
+                    ))
+                },
+            ),
+        ]
+    }
+
+    fn operation_id(&self) -> OperationId {
+        self.common.operation_id
+    }
+}
+
+impl SendCancellableStateMachine {
+    async fn transition_cancel(
+        dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
+        old_state: SendCancellableStateMachine,
+        context: MintClientContext,
+        global_context: DynGlobalClientContext,
+        user_triggered: bool,
+    ) -> SendCancellableStateMachine {
+        let refund_range =
+            reclaim_sent_notes(dbtx, old_state.common.clone(), context, global_context).await;
+
+        let state = if user_triggered {
+            SendCancellableSMState::UserRefund(SendCancellableSMRefund { refund_range })
+        } else {
+            SendCancellableSMState::TimeoutRefund(SendCancellableSMRefund { refund_range })
+        };
+
+        SendCancellableStateMachine {
+            common: old_state.common,
+            state,
+        }
+    }
+}
+
+async fn await_timeout_cancel(deadline: SystemTime) {
+    if let Ok(time_until_deadline) = deadline.duration_since(time::now()) {
+        runtime::sleep(time_until_deadline).await;
+    }
+}
+
+async fn reclaim_sent_notes(
+    dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
+    common: SendCancellableSMCommon,
+    context: MintClientContext,
+    global_context: DynGlobalClientContext,
+) -> OutPointRange {
+    let amount_unit = context.amount_unit;
+    let inputs = common
+        .spendable_notes
+        .iter()
+        .map(|spendable_note| ClientInput::<MintInput> {
+            input: MintInput::new_v0(spendable_note.note()),
+            keys: vec![spendable_note.keypair],
+            amounts: Amounts::new_custom(amount_unit, spendable_note.amount()),
+        })
+        .collect();
+
+    global_context
+        .claim_inputs(dbtx, ClientInputBundle::new_no_sm(inputs))
+        .await
+        .expect("Cannot claim input, additional funding needed")
+}

--- a/modules/fedimint-mintv2-tests/tests/tests.rs
+++ b/modules/fedimint-mintv2-tests/tests/tests.rs
@@ -1,4 +1,5 @@
 use std::pin::pin;
+use std::time::Duration;
 
 use anyhow::ensure;
 use async_stream::stream;
@@ -14,7 +15,8 @@ use fedimint_dummy_server::DummyInit;
 use fedimint_eventlog::{Event, EventLogEntry, EventLogId};
 use fedimint_mintv2_client::{
     ECash, FinalReceiveOperationState, MintClientInit, MintClientModule, ReceivePaymentEvent,
-    ReceivePaymentStatus, ReceivePaymentUpdateEvent, SendPaymentEvent,
+    ReceivePaymentStatus, ReceivePaymentUpdateEvent, SendCancellableOperationState,
+    SendPaymentEvent,
 };
 use fedimint_mintv2_common::KIND;
 use fedimint_mintv2_server::MintInit;
@@ -291,6 +293,164 @@ async fn double_spend_is_rejected() -> anyhow::Result<()> {
     };
     assert_eq!(update.operation_id, receive.operation_id);
     assert_eq!(update.status, ReceivePaymentStatus::Rejected);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn cancellable_send_can_be_manually_refunded() -> anyhow::Result<()> {
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed_not_degraded().await;
+
+    let client = fed.new_client().await;
+    issue_ecash(&client, Amount::from_sats(10_000)).await?;
+
+    let mint_module = client.get_first_module::<MintClientModule>()?;
+    let balance_before = client.get_balance_for_btc().await?;
+
+    let (operation_id, _ecash) = mint_module
+        .send_cancellable(
+            Amount::from_sats(1_000),
+            Value::Null,
+            false,
+            Duration::from_secs(60),
+        )
+        .await?;
+    let balance_after_send = client.get_balance_for_btc().await?;
+
+    assert!(balance_after_send < balance_before);
+
+    let mut updates = mint_module
+        .subscribe_send_cancellable(operation_id)
+        .await?
+        .into_stream();
+
+    assert_eq!(
+        updates.next().await,
+        Some(SendCancellableOperationState::Created)
+    );
+
+    mint_module.try_cancel_send_cancellable(operation_id).await;
+
+    assert_eq!(
+        updates.next().await,
+        Some(SendCancellableOperationState::UserCanceledProcessing)
+    );
+    assert_eq!(
+        updates.next().await,
+        Some(SendCancellableOperationState::UserCanceledSuccess)
+    );
+
+    let balance_after_cancel = client.get_balance_for_btc().await?;
+
+    assert!(balance_after_cancel > balance_after_send);
+    assert!(balance_after_cancel <= balance_before);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn cancellable_send_manual_refund_fails_after_receive() -> anyhow::Result<()> {
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed_not_degraded().await;
+
+    let (client_send, client_receive) = fed.two_clients().await;
+    issue_ecash(&client_send, Amount::from_sats(10_000)).await?;
+
+    let sender_mint = client_send.get_first_module::<MintClientModule>()?;
+    let receiver_mint = client_receive.get_first_module::<MintClientModule>()?;
+    let sender_balance_before = client_send.get_balance_for_btc().await?;
+
+    let (send_operation_id, ecash) = sender_mint
+        .send_cancellable(
+            Amount::from_sats(1_000),
+            Value::Null,
+            false,
+            Duration::from_secs(60),
+        )
+        .await?;
+    let sender_balance_after_send = client_send.get_balance_for_btc().await?;
+
+    assert!(sender_balance_after_send < sender_balance_before);
+
+    let receive_operation_id = receiver_mint.receive(ecash, Value::Null).await?;
+    let receive_state = receiver_mint
+        .await_final_receive_operation_state(receive_operation_id)
+        .await?;
+
+    assert_eq!(receive_state, FinalReceiveOperationState::Success);
+
+    let mut updates = sender_mint
+        .subscribe_send_cancellable(send_operation_id)
+        .await?
+        .into_stream();
+
+    assert_eq!(
+        updates.next().await,
+        Some(SendCancellableOperationState::Created)
+    );
+
+    sender_mint
+        .try_cancel_send_cancellable(send_operation_id)
+        .await;
+
+    assert_eq!(
+        updates.next().await,
+        Some(SendCancellableOperationState::UserCanceledProcessing)
+    );
+    assert_eq!(
+        updates.next().await,
+        Some(SendCancellableOperationState::UserCanceledFailure)
+    );
+
+    let sender_balance_after_failed_cancel = client_send.get_balance_for_btc().await?;
+
+    assert!(sender_balance_after_failed_cancel <= sender_balance_after_send);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn cancellable_send_is_refunded_after_timeout() -> anyhow::Result<()> {
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed_not_degraded().await;
+
+    let client = fed.new_client().await;
+    issue_ecash(&client, Amount::from_sats(10_000)).await?;
+
+    let mint_module = client.get_first_module::<MintClientModule>()?;
+    let balance_before = client.get_balance_for_btc().await?;
+
+    let (operation_id, _ecash) = mint_module
+        .send_cancellable(
+            Amount::from_sats(1_000),
+            Value::Null,
+            false,
+            Duration::from_millis(10),
+        )
+        .await?;
+    let balance_after_send = client.get_balance_for_btc().await?;
+
+    assert!(balance_after_send < balance_before);
+
+    let mut updates = mint_module
+        .subscribe_send_cancellable(operation_id)
+        .await?
+        .into_stream();
+
+    assert_eq!(
+        updates.next().await,
+        Some(SendCancellableOperationState::Created)
+    );
+    assert_eq!(
+        updates.next().await,
+        Some(SendCancellableOperationState::Refunded)
+    );
+
+    let balance_after_refund = client.get_balance_for_btc().await?;
+
+    assert!(balance_after_refund > balance_after_send);
+    assert!(balance_after_refund <= balance_before);
 
     Ok(())
 }


### PR DESCRIPTION
Introduces a new mintv1-style "send_cancellable" operation to the mintv2 module. Existing mintv2 "send" didn't have a bespoke SM, so we add one (mirroring the mintv1 operation states). We retain existing "send" behavior and API, and expose a new "send_cancellable" method together with a subscribe function.
